### PR TITLE
Code generator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 npm i -g hygen
 
 hygen component help
-hygen component new --name Pizza --path components/elements
+hygen component new --name Pizza --path components/elements/pizza
 hygen component store pizzas
 hygen component api pizzas
 ```

--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@
 
 ## Анализ размера сборки
 `npm run build-analize`
+
+
+## Code generator
+
+Для автоматического создания типовых файлов
+можно использовать [hygen.io](http://www.hygen.io/)
+
+```
+npm i -g hygen
+
+hygen component help
+hygen component new --name Pizza --path components/elements
+hygen component store pizzas
+hygen component api pizzas
+```
+
+Шаблоны и пути к файлам можно редактировать в папке `_templates`
+

--- a/_templates/component/api/api.ejs.t
+++ b/_templates/component/api/api.ejs.t
@@ -1,0 +1,10 @@
+---
+to: src/api/<%= name %>.js
+---
+import api from '@api';
+
+export default {
+  load: () => {
+    return api.get(`/api/v1/<%= name %>`);
+  },
+};

--- a/_templates/component/help/index.ejs.t
+++ b/_templates/component/help/index.ejs.t
@@ -1,0 +1,6 @@
+---
+message: |
+  hygen {bold component new} --name Pizza --path components/elements
+  hygen {bold component store} pizzas
+  hygen {bold component api} pizzas
+---

--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -1,0 +1,23 @@
+---
+to: src/<%= path %>/index.js
+---
+import React from 'react';
+import PropTypes from 'prop-types';
+import cn from 'classnames';
+import themes from '@utils/themes';
+import './style.less';
+
+const <%= h.inflection.camelize(name) %> = React.memo((props) => {
+  const { theme } = props;
+  return <div className={cn('<%= h.inflection.camelize(name) %>', themes(<%= h.inflection.camelize(name) %>, theme))} />;
+});
+
+<%= h.inflection.camelize(name) %>.propTypes = {
+  theme: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+};
+
+<%= h.inflection.camelize(name) %>.defaultProps = {
+  theme: '',
+};
+
+export default <%= h.inflection.camelize(name) %>;

--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -7,9 +7,9 @@ import cn from 'classnames';
 import themes from '@utils/themes';
 import './style.less';
 
-const <%= h.inflection.camelize(name) %> = React.memo((props) => {
+const <%= h.inflection.camelize(name) %> = React.memo(props => {
   const { theme } = props;
-  return <div className={cn('<%= h.inflection.camelize(name) %>', themes(<%= h.inflection.camelize(name) %>, theme))} />;
+  return <div className={cn('<%= h.inflection.camelize(name) %>', themes('<%= h.inflection.camelize(name) %>', theme))} />;
 });
 
 <%= h.inflection.camelize(name) %>.propTypes = {

--- a/_templates/component/new/stories.ejs.t
+++ b/_templates/component/new/stories.ejs.t
@@ -1,0 +1,16 @@
+---
+to: src/<%= path %>/stories.js
+---
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withInfo } from '@storybook/addon-info';
+
+import <%= h.inflection.camelize(name) %> from './index';
+
+storiesOf('elements/<%= h.inflection.camelize(name) %>', module).add(
+  'default',
+  withInfo()(() => (
+    <<%= h.inflection.camelize(name) %> onClick={action('onClick')} theme={'default'} />
+  )),
+);

--- a/_templates/component/new/style.ejs.t
+++ b/_templates/component/new/style.ejs.t
@@ -1,0 +1,4 @@
+---
+to: src/<%= path %>/style.less
+---
+.<%= h.inflection.camelize(name) %> {}

--- a/_templates/component/store/actions.ejs.t
+++ b/_templates/component/store/actions.ejs.t
@@ -1,0 +1,35 @@
+---
+to: src/store/<%= name %>/actions.js
+---
+import store from '@store';
+import * as api from '@api';
+
+export const types = {
+  RESET: Symbol('RESET'),
+  LOAD: Symbol('LOAD'),
+};
+
+export default {
+  reset: () => {
+    store.dispatch({ type: types.RESET });
+  },
+
+  load: async params => {
+    store.dispatch({ type: types.LOAD, payload: { wait: true, errors: null } });
+    try {
+      const response = await api.<%= name %>.load(params);
+      const result = response.data.result;
+      store.dispatch({ type: types.LOAD, payload: { ...result, wait: false, errors: null } });
+      return result;
+    } catch (e) {
+      if (e.response?.data?.error?.data) {
+        store.dispatch({
+          type: types.LOAD,
+          payload: { wait: false, errors: e.response.data.error.data.issues },
+        });
+      } else {
+        throw e;
+      }
+    }
+  },
+};

--- a/_templates/component/store/reducer.ejs.t
+++ b/_templates/component/store/reducer.ejs.t
@@ -1,0 +1,24 @@
+---
+to: src/store/<%= name %>/reducer.js
+---
+import reducer from '@utils/reducer';
+import { types } from './actions.js';
+
+const initState = {
+  result: [],
+  wait: false,
+  errors: null,
+};
+
+export default reducer(initState, {
+  [types.RESET]: state => {
+    return { ...initState };
+  },
+
+  [types.LOAD]: (state, { payload }) => {
+    return {
+      ...state,
+      ...payload,
+    };
+  },
+});


### PR DESCRIPTION
Предлагаю добавить генератор кода для возможности автоматического создания типовых файлов.  Как пример этот - http://www.hygen.io/

Сейчас для создания компонента со стором, привязкой к апи и пр. нужно в среднем создать 5-6 файлов и это отнимает время, особенно при старте проекта.  

Можно упростить до 3 строчек. При необходимости можно добавить другие шаблоны (например если нужны тесты).  

## Примеры

Создание базового компонента Pizza с импортами, дефолтными proptypes и пр. (3 файла на выходе index.js, style.less, strories.js). 

`hygen component new --name Pizza --path components/elements/pizza`

Создание стора (actions.js, reducer.js)

`hygen component store pizzas`

Создание файла апи (pizzas.js)

`hygen component api pizzas`

## Пример шаблона:

```
---
to: src/<%= path %>/index.js
---
import React from 'react';
import PropTypes from 'prop-types';
import cn from 'classnames';
import themes from '@utils/themes';
import './style.less';

const <%= h.inflection.camelize(name) %> = React.memo((props) => {
  const { theme } = props;
  return <div className={cn('<%= h.inflection.camelize(name) %>', themes('<%= h.inflection.camelize(name) %>', theme))} />;
});

<%= h.inflection.camelize(name) %>.propTypes = {
  theme: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
};

<%= h.inflection.camelize(name) %>.defaultProps = {
  theme: '',
};

export default <%= h.inflection.camelize(name) %>;
```