### PR TITLE
Add the auto injection of imports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.ejs.t]
+insert_final_newline = false

--- a/_templates/component/api/inject_api.ejs.t
+++ b/_templates/component/api/inject_api.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: src/api/index.js
+skip_if: <%= name %>
+append: true
+---
+export { default as <%= name %> } from './<%= name %>.js';

--- a/_templates/component/store/inject_actions.ejs.t
+++ b/_templates/component/store/inject_actions.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: src/store/actions.js
+skip_if: <%= name %>
+append: true
+---
+export { default as <%= name %> } from './<%= name %>/actions';

--- a/_templates/component/store/inject_reducer.ejs.t
+++ b/_templates/component/store/inject_reducer.ejs.t
@@ -1,0 +1,7 @@
+---
+inject: true
+to: src/store/reducers.js
+skip_if: <%= name %>
+append: true
+---
+export { default as <%= name %> } from './<%= name %>/reducer';


### PR DESCRIPTION
Добавил автодобавление импортов для апи и стора. 

## Пример:

До:

```
export { default as session } from './session/reducer';
export { default as modal } from './modal/reducer';
```

` hygen component store pizzas`

После:

```
export { default as session } from './session/reducer';
export { default as modal } from './modal/reducer';
export { default as pizzas} from './pizzas/reducer';
```