### PR TITLE
Add the correct prettier configuration for less files

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,15 @@
 module.exports = {
-  "printWidth": 100,
-  "parser": "flow",
+  printWidth: 100,
+  parser: 'flow',
   singleQuote: true,
   arrowParens: 'avoid',
-  trailingComma: 'all'
+  trailingComma: 'all',
+  overrides: [
+    {
+      files: '*.less',
+      options: {
+        parser: 'less',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Сейчас prettier не работает для less файлов. По крайней мере у меня в Webstorm 2020.1

![2020-05-08 133853](https://user-images.githubusercontent.com/16918282/81398473-eafb8a80-9131-11ea-8e38-f12e62c29eda.png)

Добавил конфиг. 
